### PR TITLE
Update SSH action and add MAIL_PASSWORD in Env Var for CI/CD

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -77,21 +77,22 @@ jobs:
           target: /home/cxbox/demo
           rm: true
       - name: prepare - add docker env varialbes populated from secrets
-        uses: appleboy/ssh-action@v0.1.10
+        uses: appleboy/ssh-action@v1.0.0
+        env:
+          MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
         with:
           host: 188.124.37.74
           username: ${{ secrets.CXBOX_DEMO_SSH_USER }}
           password: ${{ secrets.CXBOX_DEMO_SSH_PASSWORD }}
           port: 22
+          envs: MAIL_PASSWORD
           script: |
             sudo mkdir /home/cxbox/demo || true
             sudo chmod -R 777 /home/cxbox/demo || true
             cd /home/cxbox/demo
             echo "MAIL_PASSWORD=$MAIL_PASSWORD" > '.env'
-        env:
-          MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
       - name: start
-        uses: appleboy/ssh-action@v0.1.10
+        uses: appleboy/ssh-action@v1.0.0
         with:
           host: 188.124.37.74
           username: ${{ secrets.CXBOX_DEMO_SSH_USER }}


### PR DESCRIPTION
Updated SSH action to the latest version v1.0.0 and moved environment variables to an earlier stage in the GitHub workflow for the ability to capture mail password from the GitHub secrets for the Continuous Integration / Continuous Deployment (CI/CD) pipeline. 