### PR TITLE
CXBOX-433 | Info widgets in multiple columns

### DIFF
--- a/ui/src/components/widgets/Info/Info.less
+++ b/ui/src/components/widgets/Info/Info.less
@@ -1,0 +1,3 @@
+.margin {
+    margin: 0 -12px;
+}

--- a/ui/src/components/widgets/Info/Info.tsx
+++ b/ui/src/components/widgets/Info/Info.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import cn from 'classnames'
 import { interfaces } from '@cxbox-ui/core'
 import { useDispatch } from 'react-redux'
 import { useAppSelector } from '@store'
@@ -6,9 +7,11 @@ import { actions } from '@cxbox-ui/core'
 import InfoRow from './components/InfoRow'
 import { Row } from 'antd'
 import { useFlatFormFields } from '@hooks/useFlatFormFields'
+import { AppWidgetInfoMeta } from '@interfaces/widget'
+import styles from './Info.less'
 
 interface InfoProps {
-    meta: interfaces.WidgetInfoMeta
+    meta: AppWidgetInfoMeta
 }
 
 /**
@@ -45,7 +48,7 @@ function Info({ meta }: InfoProps) {
             />
         ))
 
-    return <Row>{InfoRows}</Row>
+    return <Row className={cn({ [styles.margin]: meta.options?.layout?.titleMode })}>{InfoRows}</Row>
 }
 
 export default React.memo(Info)

--- a/ui/src/components/widgets/Info/components/InfoCell.tsx
+++ b/ui/src/components/widgets/Info/components/InfoCell.tsx
@@ -5,13 +5,15 @@ import InfoValueWrapper from './InfoValueWrapper'
 import { EMPTY_ARRAY } from '@constants'
 import { useAppSelector } from '@store'
 import { interfaces } from '@cxbox-ui/core'
+import { AppWidgetInfoMeta } from '@interfaces/widget'
+
 const { FieldType } = interfaces
 
 export interface ValueCellProps {
     row: interfaces.LayoutRow
     colSpan: number
     cursor: string
-    meta: interfaces.WidgetInfoMeta
+    meta: AppWidgetInfoMeta
     field: interfaces.WidgetInfoField
     onDrillDown: (widgetName: string, cursor: string, bcName: string, fieldKey: string) => void
 }
@@ -55,7 +57,7 @@ function InfoCell({ field, colSpan, row, meta, cursor, onDrillDown }: ValueCellP
             data-test-field-title={field.label || field.title}
             data-test-field-key={field.key}
         >
-            <InfoValueWrapper key={field.key} row={row} colSpan={colSpan}>
+            <InfoValueWrapper key={field.key} row={row} colSpan={colSpan} titleMode={meta.options?.layout?.titleMode}>
                 {field.label?.length !== 0 && (
                     <div className={styles.labelArea}>
                         <span className={styles.label}>{field.label}</span>

--- a/ui/src/components/widgets/Info/components/InfoRow.module.css
+++ b/ui/src/components/widgets/Info/components/InfoRow.module.css
@@ -6,3 +6,7 @@
 .rowWrapper:last-child [class^="InfoValueWrapper_fieldArea"] {
     border-bottom: 0;
 }
+
+.rowWrapper:first-child:not(:last-child) [class*="InfoValueWrapper_rowDirection"] {
+    border-top: 0;
+}

--- a/ui/src/components/widgets/Info/components/InfoRow.tsx
+++ b/ui/src/components/widgets/Info/components/InfoRow.tsx
@@ -7,9 +7,10 @@ import { useAppSelector } from '@store'
 import { EMPTY_ARRAY } from '@constants'
 import { interfaces } from '@cxbox-ui/core'
 import { buildBcUrl } from '@utils/buildBcUrl'
+import { AppWidgetInfoMeta } from '@interfaces/widget'
 
 export interface InfoRowProps {
-    meta: interfaces.WidgetInfoMeta
+    meta: AppWidgetInfoMeta
     flattenWidgetFields: interfaces.WidgetInfoField[]
     onDrillDown: (widgetName: string, cursor: string, bcName: string, fieldKey: string) => void
     row: interfaces.LayoutRow

--- a/ui/src/components/widgets/Info/components/InfoValueWrapper.module.css
+++ b/ui/src/components/widgets/Info/components/InfoValueWrapper.module.css
@@ -1,4 +1,3 @@
-
 .fieldArea {
     display: flex;
     min-height: 52px;
@@ -6,6 +5,19 @@
     border-bottom: 1px solid #d5d5d5;
 }
 
+.columnDirectionDefault {
+    flex-direction: column;
+}
+
 .columnDirection {
     flex-direction: column;
+    align-items: flex-start;
+    margin: 0 12px;
+    border: none;
+}
+
+.rowDirection {
+    margin: 0 12px;
+    border-bottom: none;
+    border-top: 1px solid #d5d5d5;
 }

--- a/ui/src/components/widgets/Info/components/InfoValueWrapper.tsx
+++ b/ui/src/components/widgets/Info/components/InfoValueWrapper.tsx
@@ -3,16 +3,28 @@ import React, { ReactNode } from 'react'
 import styles from './InfoValueWrapper.module.css'
 import { Col } from 'antd'
 import { interfaces } from '@cxbox-ui/core'
+import { ETitleMode } from '@interfaces/widget'
 
 interface ValueWrapperProps {
     row: interfaces.LayoutRow
+    titleMode?: ETitleMode
     colSpan?: number
     children?: ReactNode
 }
-function InfoValueWrapper({ row, colSpan, children }: ValueWrapperProps) {
+function InfoValueWrapper({ row, titleMode, colSpan, children }: ValueWrapperProps) {
+    const isMultipleColumns = row.cols.length > 1
+
     return (
         <Col span={colSpan}>
-            <div className={cn(styles.fieldArea, { [styles.columnDirection]: row.cols.length > 1 })}>{children}</div>
+            <div
+                className={cn(styles.fieldArea, {
+                    [styles.columnDirectionDefault]: isMultipleColumns && titleMode !== ETitleMode.left,
+                    [styles.columnDirection]: titleMode === ETitleMode.top,
+                    [styles.rowDirection]: titleMode === ETitleMode.left
+                })}
+            >
+                {children}
+            </div>
         </Col>
     )
 }

--- a/ui/src/interfaces/widget.ts
+++ b/ui/src/interfaces/widget.ts
@@ -173,3 +173,16 @@ export type FileUploadFieldMeta = CoreFileUploadFieldMeta & {
 }
 
 export type WidgetField = CoreWidgetField | FileUploadFieldMeta
+
+export const enum ETitleMode {
+    left = 'left',
+    top = 'top'
+}
+
+export interface AppWidgetInfoMeta extends interfaces.WidgetInfoMeta {
+    options?: interfaces.WidgetInfoMeta['options'] & {
+        layout?: interfaces.WidgetOptions['layout'] & {
+            titleMode?: ETitleMode
+        }
+    }
+}


### PR DESCRIPTION
Added new layout option in WidgetInfoMeta options - "options": { "layout": { "titleMode": "left" | "top" }}