### PR TITLE
CXBOX-873 | Fixes 'multi-role' = false mode, when a user switched roles, then UI was forced to ignore role change by backend in some cases

### DIFF
--- a/src/main/java/org/demo/conf/security/SecurityConfig.java
+++ b/src/main/java/org/demo/conf/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import static org.demo.conf.security.basic.AuthBasicConfigProperties.APP_AUTH_BA
 
 import org.cxbox.core.config.properties.UIProperties;
 import org.cxbox.meta.metahotreload.conf.properties.MetaConfigurationProperties;
+import org.demo.conf.cxbox.customization.role.UserRoleService;
 import org.demo.conf.security.basic.AuthBasicConfigProperties;
 import org.demo.conf.security.basic.CustomBasicAuthenticationEntryPoint;
 import org.demo.conf.security.oidc.CxboxAuthUserRepository;
@@ -39,12 +40,12 @@ public class SecurityConfig {
 	private final AuthBasicConfigProperties authBasicConfigProperties;
 
 	public SecurityConfig(UserService userService, UIProperties uiProperties, MetaConfigurationProperties metaConfigurationProperties, @Qualifier("tokenConverterProperties") TokenConverterProperties properties, CxboxAuthUserRepository cxboxAuthUserRepository,
-			AuthBasicConfigProperties authBasicConfigProperties) {
+			AuthBasicConfigProperties authBasicConfigProperties, UserRoleService userRoleService) {
 		this.uiProperties = uiProperties;
 		this.metaConfigurationProperties = metaConfigurationProperties;
 		this.authBasicConfigProperties = authBasicConfigProperties;
 		this.oidcJwtTokenConverter = new OidcJwtTokenConverter(new JwtGrantedAuthoritiesConverter(), properties,
-				userService, cxboxAuthUserRepository, uiProperties
+				userService, userRoleService, cxboxAuthUserRepository, uiProperties
 		);
 	}
 

--- a/src/main/java/org/demo/conf/security/oidc/OidcJwtTokenConverter.java
+++ b/src/main/java/org/demo/conf/security/oidc/OidcJwtTokenConverter.java
@@ -1,15 +1,16 @@
 package org.demo.conf.security.oidc;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
 import org.cxbox.api.service.session.CxboxUserDetailsInterface;
 import org.cxbox.core.config.properties.UIProperties;
+import org.demo.conf.cxbox.customization.role.UserRoleService;
 import org.demo.conf.cxbox.customization.role.UserService;
 import org.demo.entity.core.User;
 import org.springframework.core.convert.converter.Converter;
@@ -19,6 +20,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 
+@RequiredArgsConstructor
 public class OidcJwtTokenConverter implements Converter<Jwt, OidcAuthenticationToken> {
 
 	private static final String RESOURCE_ACCESS = "resource_access";
@@ -33,20 +35,11 @@ public class OidcJwtTokenConverter implements Converter<Jwt, OidcAuthenticationT
 
 	private final UserService userService;
 
+	private final UserRoleService userRoleService;
+
 	private final CxboxAuthUserRepository cxboxAuthUserRepository;
 
 	private final UIProperties uiProperties;
-
-	public OidcJwtTokenConverter(
-			JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter,
-			TokenConverterProperties properties, UserService userService, CxboxAuthUserRepository cxboxAuthUserRepository,
-			UIProperties uiProperties) {
-		this.jwtGrantedAuthoritiesConverter = jwtGrantedAuthoritiesConverter;
-		this.properties = properties;
-		this.userService = userService;
-		this.cxboxAuthUserRepository = cxboxAuthUserRepository;
-		this.uiProperties = uiProperties;
-	}
 
 	@Override
 	public OidcAuthenticationToken convert(@NonNull Jwt jwt) {
@@ -74,7 +67,7 @@ public class OidcJwtTokenConverter implements Converter<Jwt, OidcAuthenticationT
 				user,
 				uiProperties.isMultiRoleEnabled()
 						? roles.stream().map(SimpleGrantedAuthority::getAuthority).collect(Collectors.toSet())
-						: roles.stream().findFirst().map(SimpleGrantedAuthority::getAuthority).map(Set::of).orElse(new HashSet<>())
+						: userRoleService.getMainUserRoleKey(user)
 		);
 		return new OidcAuthenticationToken(jwt, authorities, login, userDetails);
 


### PR DESCRIPTION
multi-role' = false mode, when a user switched roles has many roles and switches them. In some cases, the main role flag was not set on a chosen role, so UI was forced to choose the main role back